### PR TITLE
fix default root value assignment

### DIFF
--- a/src/resolve-data.ts
+++ b/src/resolve-data.ts
@@ -39,7 +39,8 @@ export function resolveData(data: any, operation: AugmentedOperation, entities: 
    * Combine our custom resolvers with the default
    * resolver: (field, root) => root[field]
    */
-  const resolver: Resolver = (fieldName, root = {}, _, __, info) => {
+  const resolver: Resolver = (fieldName, root: _root, _, __, info) => {
+    const root = _root == null ? {} : _root;
     const { resultKey } = info; // this is the new field name if we use an alias => resultKey: fieldName
     const { __typename: typeName } = root;
 

--- a/src/resolve-data.ts
+++ b/src/resolve-data.ts
@@ -39,7 +39,7 @@ export function resolveData(data: any, operation: AugmentedOperation, entities: 
    * Combine our custom resolvers with the default
    * resolver: (field, root) => root[field]
    */
-  const resolver: Resolver = (fieldName, root: _root, _, __, info) => {
+  const resolver: Resolver = (fieldName, _root, _, __, info) => {
     const root = _root == null ? {} : _root;
     const { resultKey } = info; // this is the new field name if we use an alias => resultKey: fieldName
     const { __typename: typeName } = root;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/16778318/93180631-c050bc80-f737-11ea-8c9c-ecc646021a30.png)

![image](https://user-images.githubusercontent.com/16778318/93180708-d8c0d700-f737-11ea-9aee-1dbe42400be9.png)


When `data` coming from the server is `null`, that is value of `root`, and so the default assignment of empty object fails, and thus cannot be destructured.

It's been working until now if the server returns something within data, which has been done in some apps, but this is not default behaviour and does not fit with URQL's types where `data` can be undefined:
From URQL's types:
```
export interface UseMutationState<T> {
    fetching: boolean;
    stale: boolean;
    data?: T;
    error?: CombinedError;
    extensions?: Record<string, any>;
    operation?: Operation;
}
```
This happens for both queries and mutations